### PR TITLE
corrected text intersection with objetcs

### DIFF
--- a/src/compas_cadwork/scene/instructionobject.py
+++ b/src/compas_cadwork/scene/instructionobject.py
@@ -44,7 +44,7 @@ class Text3dSceneObject(CadworkSceneObject):
 
         Return
         -------
-        triple(cadwork.point_3d, cadwork.point_3d, cadwork.point_3d)
+        tuple(cadwork.point_3d, cadwork.point_3d, cadwork.point_3d)
             Translation vectors in x, y and z direction.
         """
         bb = get_bounding_box_vertices_local(element_id, [element_id])


### PR DESCRIPTION
added a small tolerance so the text doesnt intersect with the cadwork geometry

![image](https://github.com/gramaziokohler/compas_cadwork/assets/34544179/69184a5e-dcd5-4391-a9c2-1bf479e25783)