### PR TITLE
fix the set_attribute funcntion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 ### Changed
+* Changed `Element.set_attribute` args to use `user_attribute_id` as int and `user_attribute` as string.
 
 ### Removed
 

--- a/src/compas_cadwork/datamodel/element.py
+++ b/src/compas_cadwork/datamodel/element.py
@@ -248,20 +248,25 @@ class Element:
         """
         return (Element(e_id) for e_id in ec.get_active_identifiable_element_ids())
 
-    def set_attribute(self, name, value):
+    def set_attribute(self, attribute_number: int, name: str, value: str):
         """Sets an attribute on the Element
 
         Parameters
         ----------
+        attribute_number : int
+            The number of the attribute (1-10)
         name : str
             The name of the attribute
         value : str
             The value of the attribute
 
         """
-        ac.set_user_attribute([self.id], name, value)
+        ac.set_user_attribute_name(number=attribute_number, user_attribute_name=name)
+        ac.set_user_attribute([self.id], number=attribute_number, user_attribute=value)
 
-    def remove_attribute(self, name):
+    # actully this only use the user_attribute number; no pass the elment id
+    # I am not sure how it defines which element to remove the attribute from
+    def remove_attribute(self, attribute_number):
         """Removes an attribute from the Element
 
         Parameters
@@ -270,7 +275,7 @@ class Element:
             The name of the attribute
 
         """
-        ac.delete_user_attribute([self.id], name)
+        ac.delete_user_attribute(number=attribute_number)
 
     def set_is_instruction(self, value: bool, instruction_id: Optional[str] = None):
         """Sets the is_instruction attribute on the Element

--- a/src/compas_cadwork/datamodel/element.py
+++ b/src/compas_cadwork/datamodel/element.py
@@ -248,34 +248,45 @@ class Element:
         """
         return (Element(e_id) for e_id in ec.get_active_identifiable_element_ids())
 
-    def set_attribute(self, attribute_number: int, name: str, value: str):
+    def set_attribute(self, attribute_number: int, name_or_value: str, value: Optional[str] = None):
         """Sets an attribute on the Element
 
         Parameters
         ----------
         attribute_number : int
             The number of the attribute (1-10)
-        name : str
-            The name of the attribute
-        value : str
+        name_or_value : str
+            If ``value`` is provided, this is the name of the attribute.
+            Otherwise, this is the user attribute value.
+        value : str, optional
             The value of the attribute
 
         """
-        ac.set_user_attribute_name(number=attribute_number, user_attribute_name=name)
-        ac.set_user_attribute([self.id], number=attribute_number, user_attribute=value)
+        if value is None:
+            user_attribute_value = name_or_value
+        else:
+            ac.set_user_attribute_name(attribute_number, name_or_value)
+            user_attribute_value = value
+
+        ac.set_user_attribute([self.id], attribute_number, user_attribute_value)
 
     # actully this only use the user_attribute number; no pass the elment id
     # I am not sure how it defines which element to remove the attribute from
-    def remove_attribute(self, attribute_number):
+    def remove_attribute(self, attribute_number: int, value: Optional[str] = None):
         """Removes an attribute from the Element
 
         Parameters
         ----------
-        name : str
-            The name of the attribute
+        attribute_number : int
+            The number of the attribute (1-10)
+        value : str, optional
+            The attribute value to remove from the user attribute list.
 
         """
-        ac.delete_user_attribute(number=attribute_number)
+        if value is None:
+            ac.delete_user_attribute(attribute_number)
+        else:
+            ac.delete_item_from_user_attribute_list(attribute_number, value)
 
     def set_is_instruction(self, value: bool, instruction_id: Optional[str] = None):
         """Sets the is_instruction attribute on the Element


### PR DESCRIPTION
### What type of change is this?
It was the issue with `set_attribute` take wrong type of argument. The function in cadwork api:
```
import attribute_controller as ac
ac.set_user_attribute(element_id_list: List[ElementId], number: UserAttributeId, user_attribute: str)
```
it should take number: int(user attribute id) and `user_attribute` is `string`

- [X] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

- [X] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [X] Test with cadwork3d app