### PR TITLE
Add "do not merge" workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: verify-pr-checklist
+name: Verify PR checklist
 
 on:
   pull_request:
@@ -7,8 +7,7 @@ on:
       - main
 
 jobs:
-  checklist:
-    name: Verify PR checklist
+  changelog:
     runs-on: ubuntu-slim
     steps:
       - name: Checkout
@@ -21,3 +20,12 @@ jobs:
           checkNotification: Simple
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  do-not-merge:
+    if: "contains(github.event.pull_request.labels.*.name, 'O: Requires rebasing')"
+    runs-on: ubuntu-slim
+    steps:
+      - name: Check for label
+        run: |
+          echo "Pull request contains a label that prevents the merge."
+          echo "This workflow will now fail."
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new `Element`, `Project`, and `IfcUUID` classes.
+- Added "do not merge" workflow check to CI/CD pipeline.
 
 ### Changed
 


### PR DESCRIPTION
Tiny PR that creates a GitHub Actions workflow to prevent merge if the `O: Requires rebasing` label is attached to the PR.

The goal is to prevent merging PRs that are not ready (yet are approved and pass all checks) by accident.