### PR TITLE
Add `HOLLOWCORE`, `JOIST` and `LINTEL` IFC predefined types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added User Guide and Developer Guide to documentation.
 - Added backwards compatibility with Python 3.10 (Cadwork 2024).
+- Added `IfcPredefinedType.HOLLOWCORE`, `IfcPredefinedType.JOIST` and `IfcPredefinedType.LINTEL` enumeration values.
 
 ### Changed
 

--- a/docs/compatibility_extension.py
+++ b/docs/compatibility_extension.py
@@ -1,4 +1,5 @@
 import ast
+import re
 from typing import Any
 
 from griffe import Attribute
@@ -41,6 +42,7 @@ class CompatibilityExtension(Extension):
             }
 
     def on_attribute(self, *, attr: Attribute, **kwargs: Any) -> None:
+        self._parse_decorators_from_docstring(attr)
         self._add_compatibility_table(attr)
 
     def on_class(self, *, cls: Class, **kwargs: Any) -> None:
@@ -49,6 +51,22 @@ class CompatibilityExtension(Extension):
 
     def on_function(self, *, func: Function, **kwargs: Any) -> None:
         self._add_compatibility_table(func)
+
+    def _parse_decorators_from_docstring(self, obj: Object) -> None:
+        if not obj.docstring:
+            return
+        decorator_match = re.search(r"@requires_cadwork\((\d{4})\)", obj.docstring.value)
+        if not decorator_match:
+            return
+
+        # Extract minimum Cadwork version
+        min_cadwork_version = int(decorator_match[1])
+        obj.extra[EXTENSION_NAMESPACE] = {
+            "min_cadwork_version": min_cadwork_version,
+        }
+
+        # Remove decorator from docstring
+        obj.docstring.value = obj.docstring.value.replace(decorator_match[0], "").strip()
 
     def _add_compatibility_table(self, obj: Object) -> None:
         min_cadwork_version = obj.extra.get(EXTENSION_NAMESPACE, {}).get("min_cadwork_version", CADWORK_VERSIONS[0])

--- a/docs/user-guide/compatibility.md
+++ b/docs/user-guide/compatibility.md
@@ -14,7 +14,10 @@ You can find which features are available in which cadwork 3d versions in the [A
 
 For your convenience, below is a summary of features that are only available in some cadwork 3d versions:
 
-| Module                     | Method / Property          | Cadwork 2024 | Cadwork 2025 | Cadwork 2026 |
-| :------------------------- | :------------------------- | :----------: | :----------: | :----------: |
-| `compas_cadwork.materials` | `FloorLayerStack.create()` |      ❌      |      ✅      |      ✅      |
-| `compas_cadwork.materials` | `RoofLayerStack.create()`  |      ❌      |      ✅      |      ✅      |
+| Module                     | Method / Property              | Cadwork 2024 | Cadwork 2025 | Cadwork 2026 |
+| :------------------------- | :----------------------------- | :----------: | :----------: | :----------: |
+| `compas_cadwork.elements`  | `IfcPredefinedType.HOLLOWCORE` |      ❌      |      ❌      |      ✅      |
+| `compas_cadwork.elements`  | `IfcPredefinedType.JOIST`      |      ❌      |      ❌      |      ✅      |
+| `compas_cadwork.elements`  | `IfcPredefinedType.LINTEL`     |      ❌      |      ❌      |      ✅      |
+| `compas_cadwork.materials` | `FloorLayerStack.create()`     |      ❌      |      ✅      |      ✅      |
+| `compas_cadwork.materials` | `RoofLayerStack.create()`      |      ❌      |      ✅      |      ✅      |

--- a/src/compas_cadwork/elements/ifc_predefined_type.py
+++ b/src/compas_cadwork/elements/ifc_predefined_type.py
@@ -36,8 +36,11 @@ class IfcPredefinedType(Enum):
     ROOF = auto()
     BEAM = auto()
     HOLLOWCORE = auto()
+    """@requires_cadwork(2026)"""
     JOIST = auto()
+    """@requires_cadwork(2026)"""
     LINTEL = auto()
+    """@requires_cadwork(2026)"""
     SPANDREL = auto()
     TBEAM = auto()
     COMPLEX = auto()

--- a/src/compas_cadwork/elements/ifc_predefined_type.py
+++ b/src/compas_cadwork/elements/ifc_predefined_type.py
@@ -5,6 +5,8 @@ from enum import auto
 
 import cadwork
 
+from compas_cadwork.utils.compatibility import CADWORK_VERSION
+
 
 class IfcPredefinedType(Enum):
     """IFC predefined type."""
@@ -33,6 +35,9 @@ class IfcPredefinedType(Enum):
     LANDING = auto()
     ROOF = auto()
     BEAM = auto()
+    HOLLOWCORE = auto()
+    JOIST = auto()
+    LINTEL = auto()
     SPANDREL = auto()
     TBEAM = auto()
     COMPLEX = auto()
@@ -235,6 +240,15 @@ class IfcPredefinedType(Enum):
             return cls.ROOF
         if raw_type.is_beam():
             return cls.BEAM
+        if CADWORK_VERSION >= 2026:
+            # Getters for these types were added in Cadwork 2026
+            # See https://github.com/cwapi3d/cwapi3dpython/commit/6a0d0a8ba6def100ebed3cb0a4b18ed3880c5de3
+            if raw_type.is_hollowcore():
+                return cls.HOLLOWCORE
+            if raw_type.is_joist():
+                return cls.JOIST
+            if raw_type.is_lintel():
+                return cls.LINTEL
         if raw_type.is_spandrel():
             return cls.SPANDREL
         if raw_type.is_tbeam():
@@ -563,6 +577,12 @@ class IfcPredefinedType(Enum):
                 raw_type.set_roof()
             case IfcPredefinedType.BEAM:
                 raw_type.set_beam()
+            case IfcPredefinedType.HOLLOWCORE:
+                raw_type.set_hollowcore()
+            case IfcPredefinedType.JOIST:
+                raw_type.set_joist()
+            case IfcPredefinedType.LINTEL:
+                raw_type.set_lintel()
             case IfcPredefinedType.SPANDREL:
                 raw_type.set_spandrel()
             case IfcPredefinedType.TBEAM:

--- a/src/compas_cadwork/elements/ifc_predefined_type.py
+++ b/src/compas_cadwork/elements/ifc_predefined_type.py
@@ -3,9 +3,31 @@ from __future__ import annotations
 from enum import Enum
 from enum import auto
 
+import bim_controller as bc
 import cadwork
+import element_controller as ec
 
 from compas_cadwork.utils.compatibility import CADWORK_VERSION
+
+
+def _get_cadwork_instance() -> cadwork.ifc_predefined_type:
+    """Get a new IFC predefined type Cadwork instance.
+
+    Under normal circumstances, we would just call `cadwork.ifc_predefined_type()` to get a new instance.
+    However, Cadwork 2024 and Cadwork 2025 have a bug in the constructor binding.
+    For those cases, we create a temporary element and get its IFC predefined type.
+
+    See https://github.com/gramaziokohler/compas_cadwork/issues/72 for more information.
+    """
+    # Polyfill for buggy versions
+    if CADWORK_VERSION < 2026:
+        element_id = ec.create_node(cadwork.point_3d(0.0, 0.0, 0.0))
+        instance = bc.get_ifc_predefined_type(element_id)
+        ec.delete_elements([element_id])
+        return instance
+
+    # Use class constructor
+    return cadwork.ifc_predefined_type()
 
 
 class IfcPredefinedType(Enum):
@@ -530,7 +552,7 @@ class IfcPredefinedType(Enum):
         cadwork.ifc_predefined_type
             Cadwork IFC predefined type.
         """
-        raw_type = cadwork.ifc_predefined_type()  # TODO(josemmo): does not work yet, there is bug in the Cadwork API
+        raw_type = _get_cadwork_instance()
         match self:
             case IfcPredefinedType.NONE:
                 raw_type.set_none()

--- a/tests/compas_cadwork/elements/test_ifc_predefined_type.py
+++ b/tests/compas_cadwork/elements/test_ifc_predefined_type.py
@@ -11,6 +11,20 @@ def test_gets_value_from_cadwork(cadwork, expected_type) -> None:
     assert IfcPredefinedType.from_cadwork(raw_type) == expected_type
 
 
+@pytest.mark.parametrize(
+    "expected_type",
+    [IfcPredefinedType.HOLLOWCORE, IfcPredefinedType.JOIST, IfcPredefinedType.LINTEL],
+)
+def test_raises_on_unsupported_type_in_cadwork_2025(cadwork, set_cadwork_version, expected_type) -> None:
+    set_cadwork_version(2025)
+    expected_method = f"is_{expected_type.name.lower()}"
+    getattr(cadwork.cadwork.ifc_predefined_type.return_value, expected_method).return_value = True
+    with pytest.raises(ValueError, match=r"Unknown Cadwork IFC predefined type"):
+        raw_type = cadwork.cadwork.ifc_predefined_type()
+        _ = IfcPredefinedType.from_cadwork(raw_type)
+    getattr(cadwork.cadwork.ifc_predefined_type.return_value, expected_method).assert_not_called()
+
+
 def test_raises_on_unknown_cadwork_type(cadwork) -> None:
     raw_type = cadwork.cadwork.ifc_predefined_type()
     with pytest.raises(ValueError, match=r"Unknown Cadwork IFC predefined type"):

--- a/tests/compas_cadwork/elements/test_ifc_predefined_type.py
+++ b/tests/compas_cadwork/elements/test_ifc_predefined_type.py
@@ -44,6 +44,16 @@ def test_exports_value_to_cadwork(cadwork, expected_type) -> None:
         case _:
             expected_method = f"set_{expected_type.name.lower()}"
     getattr(raw_type, expected_method).assert_called_once()
+    cadwork.bc.get_ifc_predefined_type.assert_not_called()
+
+
+def test_exports_value_to_cadwork_in_cadwork_2025(cadwork, set_cadwork_version) -> None:
+    set_cadwork_version(2025)
+    cadwork.ec.create_node.return_value = 1000
+    _ = IfcPredefinedType.SUPPORT.to_cadwork()
+    cadwork.ec.create_node.assert_called_once()
+    cadwork.bc.get_ifc_predefined_type.assert_called_once_with(1000)
+    cadwork.ec.delete_elements.assert_called_once_with([1000])
 
 
 @pytest.mark.parametrize("expected_type", list(IfcPredefinedType))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -196,6 +196,9 @@ class CadworkMocks:
         self.cadwork.ifc_predefined_type.return_value.is_landing.return_value = False
         self.cadwork.ifc_predefined_type.return_value.is_roof.return_value = False
         self.cadwork.ifc_predefined_type.return_value.is_beam.return_value = False
+        self.cadwork.ifc_predefined_type.return_value.is_hollowcore.return_value = False
+        self.cadwork.ifc_predefined_type.return_value.is_joist.return_value = False
+        self.cadwork.ifc_predefined_type.return_value.is_lintel.return_value = False
         self.cadwork.ifc_predefined_type.return_value.is_spandrel.return_value = False
         self.cadwork.ifc_predefined_type.return_value.is_tbeam.return_value = False
         self.cadwork.ifc_predefined_type.return_value.is_complex.return_value = False


### PR DESCRIPTION
- Adds missing types from `IfcPredefinedType` enumeration that were missing due to a bug in Cadwork 2026.
- Updates the Griffe compatibility extension to parse decorators from docstrings. This is needed as Python doesn't support decorators in enumeration properties.
- Adds polyfill for `cadwork.ifc_predefined_type()` constructor in Cadwork 2024/2025 (see #72).